### PR TITLE
Fix solver exception handling

### DIFF
--- a/pyurdme/pyurdme.py
+++ b/pyurdme/pyurdme.py
@@ -2293,19 +2293,21 @@ class URDMESolver:
                     handle = subprocess.Popen(urdme_solver_cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE)
                     stdout, stderr = handle.communicate()
                 return_code = handle.wait()
-            except OSError as e:
-                print "Error, execution of solver raised an exception: {0}".format(e)
-                print "urdme_solver_cmd = {0}".format(urdme_solver_cmd)
-
-            if return_code != 0:
-                if self.report_level >= 1:
-                    try:
+                if return_code != 0:
+                    if self.report_level >= 1:
                         print stderr, stdout
-                    except Exception as e:
-                        pass
-                print "urdme_solver_cmd = {0}".format(urdme_solver_cmd)
-                raise URDMEError("Solver execution failed, return code = {0}".format(return_code))
-
+                    raise URDMEError(
+                        "Solver execution failed, return code = {0}".format(return_code) +
+                        "\nurdme_solver_cmd = {0}".format(urdme_solver_cmd)
+                    )
+            except OSError as e:
+                # Add urdme command to exception message
+                raise URDMEError(
+                        str(e) +
+                        "\nurdme_solver_cmd = {0}".format(urdme_solver_cmd)
+                )
+                print e.args
+                raise e
 
             #Load the result from the hdf5 output file.
             try:


### PR DESCRIPTION
Avoid UnboundLocalError in case solver execution throws an exception.
Information about the solver error is now passed within the
exception message.

fix #157